### PR TITLE
Fix / Typo in beats API

### DIFF
--- a/audio_api/api/views.py
+++ b/audio_api/api/views.py
@@ -37,7 +37,7 @@ def beats(request):
         if isfile(fileName):
             beatsResponse.append({
                 "id": f,
-                "url": request.build_absolute_uri("/" + filename)
+                "url": request.build_absolute_uri("/" + fileName)
             })
 
     return HttpResponse(json.dumps(beatsResponse))


### PR DESCRIPTION
Fixed typo made while refactoring to use abs urls (breaking the whole beats route response, whoops)