### PR TITLE
Fix: URLs are generated using the STATIC_URL defined in the project settings.

### DIFF
--- a/audio_api/api/views.py
+++ b/audio_api/api/views.py
@@ -10,6 +10,7 @@ from forms import UploadForm, TtsForm, TextToRapForm
 from os import listdir
 from os.path import isfile, join
 from subprocess import call
+from django.conf import settings
 
 def index(request):
     return HttpResponse("Hey. <br />My name is Song API<br />Give me your audio!<br />I will not tell you bye,<br />I'll make songs, yo!<br />Peace homie!")
@@ -37,7 +38,7 @@ def beats(request):
         if isfile(fileName):
             beatsResponse.append({
                 "id": f,
-                "url": request.build_absolute_uri("/" + filename)
+                "url": settings.STATIC_URL + fileName
             })
 
     return HttpResponse(json.dumps(beatsResponse))
@@ -54,7 +55,7 @@ def upload(request):
             rapSongFile = rappify(filename, beatSound)
 
             return HttpResponse(json.dumps({
-                "url": request.build_absolute_uri("/" + rapSongFile)
+                "url": request.build_absolute_uri(settings.STATIC_URL + rapSongFile)
             }))
     else:
         return HttpResponse('test here: <form method="post" enctype="multipart/form-data">' + str(form) + '<input type=submit />')
@@ -92,7 +93,7 @@ def tts(request):
         # q = request.POST.get('text', 'send text plz')
         fileName = textToSpeech(**request.POST.dict())
 
-        return HttpResponse(request.build_absolute_uri("/" + fileName))
+        return HttpResponse(request.build_absolute_uri(settings.STATIC_URL + fileName))
     else:
         return HttpResponse('test here: <form method="post">' + str(form) + '<input type=submit />')
 
@@ -108,7 +109,7 @@ def textToRap(request):
         rapSongFile = rappify(speechFile, beatSound)
 
         return HttpResponse(json.dumps({
-            "url": request.build_absolute_uri("/" + rapSongFile)
+            "url": request.build_absolute_uri(settings.STATIC_URL + rapSongFile)
         }))
     else:
         return HttpResponse('test here: <form method="post">' + str(form) + '<input type=submit />')

--- a/audio_api/audio_api/settings.py
+++ b/audio_api/audio_api/settings.py
@@ -117,5 +117,5 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = 'https://rap-generator.devlabs-projects.com/'
 STATICFILES_DIRS = ['static/']


### PR DESCRIPTION
This allows you to assign paths to the server that don't start at the web root, and still generate sensible urls. Otherwise, Django has no way of knowing what the name of the server is if it's running behind nginx with url rewriting on.